### PR TITLE
Re-invite stuck unconfirmed accounts (Incomplete Accounts ticket)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ VITE_SUPABASE_PUBLISHABLE_KEY=your-public-anon-key
 # - BREVO_SENDER_EMAIL         (email sender)
 # - BREVO_SENDER_NAME          (email sender name)
 # - REFERRAL_SIGNUP_URL        (signup URL for referrals)
+# - REINVITE_REDIRECT_URL      (optional; post-confirmation landing for reinvite-incomplete)
 # - OPENAI_API_KEY             (if using AI features)
 # - STRIPE_SECRET_KEY          (if using payments)
 # - ELEVENLABS_API_KEY         (if using voice features)

--- a/docs/INCOMPLETE_ACCOUNTS.md
+++ b/docs/INCOMPLETE_ACCOUNTS.md
@@ -1,0 +1,70 @@
+# Incomplete Accounts — Re-invite Runbook
+
+Ticket: "Investigate Incomplete Accounts" (Linear, Authentications & Accounts).
+
+## Background
+
+Between January and July 2026, signup confirmation emails silently failed while
+Brevo was out of credits. Supabase recorded the send attempt
+(`confirmation_sent_at` set) but the email never went out, leaving accounts
+stuck unconfirmed — the user can't log in, and their email is "taken" so they
+can't re-register. Investigation on 2026-07-30 found **42 unconfirmed accounts
+out of 185 total** (23%), all with profiles already created by the signup
+trigger.
+
+## Components
+
+| Piece | Where | Purpose |
+|---|---|---|
+| `signup_reminders` table | `supabase/migrations/20260731_add_signup_reminders.sql` | Tracks who was re-invited, how many times, and when (admin-readable, service-role writable) |
+| `reinvite-incomplete` edge function | `supabase/functions/reinvite-incomplete/` | Generates a fresh confirmation link per stuck user and emails it via Brevo |
+| Self-service resend | `/auth` sign-in tab | "Resend confirmation email" button calling `supabase.auth.resend` — users can unstick themselves |
+
+## Running a re-invite batch
+
+Invoke with the project's **secret API key** (Dashboard → Settings → API keys →
+`sb_secret_...`), or as a signed-in admin user:
+
+```sh
+# Dry run first (default) — reports what would happen, sends nothing
+curl -X POST "https://xnbbgmkywspodwdrlzhq.supabase.co/functions/v1/reinvite-incomplete" \
+  -H "Authorization: Bearer $SB_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"excludeEmails": ["support@laceupnetowrk.com"]}'
+
+# Real send: dryRun must be explicitly false
+curl -X POST "https://xnbbgmkywspodwdrlzhq.supabase.co/functions/v1/reinvite-incomplete" \
+  -H "Authorization: Bearer $SB_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"dryRun": false, "excludeEmails": ["support@laceupnetowrk.com"]}'
+```
+
+Options (all optional): `dryRun` (default **true**), `limit` (50),
+`excludeEmails` ([]), `minAccountAgeHours` (24), `maxReminders` (3),
+`cooldownDays` (7).
+
+The response lists per-email results (`sent` / `would_send` / `skipped` +
+reason / `error`). Sends are stamped in `signup_reminders`, so re-running is
+safe: the cooldown and max-reminder guards prevent double-sending.
+
+## Email content
+
+The email is sent through Brevo's transactional API with inline HTML (no
+template setup required). Subject: "Finish setting up your LaceUP account".
+The confirmation link is a fresh Supabase `signup`-type action link — the
+originals expired long ago. Optional secret `REINVITE_REDIRECT_URL` controls
+where the link lands after verification (must be on the auth redirect
+allow-list); when unset, the project's Site URL is used.
+
+## Future automation (per Johnathan)
+
+Schedule the function (Supabase Dashboard → Integrations → Cron, or pg_cron
+calling it via `net.http_post`) daily with `{"dryRun": false}`. The built-in
+guards (min age 24h, 7-day cooldown, max 3 reminders) make it idempotent and
+spam-safe. Not enabled yet — run manually until the email copy is approved.
+
+## Monitoring
+
+- Stuck-account count: `SELECT count(*) FROM auth.users WHERE email_confirmed_at IS NULL;`
+- Reminder history: `SELECT * FROM signup_reminders ORDER BY last_reminded_at DESC;`
+- Set a Brevo low-credit alert (Brevo dashboard) — the root cause was silent credit exhaustion.

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -27,6 +27,7 @@ const Auth = () => {
   const [sport, setSport] = useState("");
   const [userType, setUserType] = useState<"athlete" | "mentor" | "employer">("athlete");
   const [loading, setLoading] = useState(false);
+  const [resendingConfirmation, setResendingConfirmation] = useState(false);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { toast } = useToast();
@@ -231,6 +232,36 @@ const Auth = () => {
       });
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleResendConfirmation = async () => {
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      toast({
+        title: "Enter your email first",
+        description: "Type your email address above, then tap resend.",
+      });
+      return;
+    }
+
+    setResendingConfirmation(true);
+    try {
+      await supabase.auth.resend({
+        type: "signup",
+        email: trimmedEmail,
+        options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
+      });
+    } catch {
+      // Deliberately swallowed: response must not reveal whether the account exists
+    } finally {
+      setResendingConfirmation(false);
+      // Same message on every outcome to prevent account enumeration
+      toast({
+        title: "Check your inbox",
+        description:
+          "If an account with that email is waiting on confirmation, a fresh confirmation email is on its way.",
+      });
     }
   };
 
@@ -520,9 +551,19 @@ const Auth = () => {
                     required
                   />
                 </div>
-                <Link to="/forgot-password" className="text-sm text-blue-500 hover:text-blue-400 hover:underline">
-                  Forgot your password?
-                </Link>
+                <div className="flex items-center justify-between">
+                  <Link to="/forgot-password" className="text-sm text-blue-500 hover:text-blue-400 hover:underline">
+                    Forgot your password?
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={handleResendConfirmation}
+                    disabled={resendingConfirmation}
+                    className="text-sm text-blue-500 hover:text-blue-400 hover:underline disabled:opacity-50"
+                  >
+                    {resendingConfirmation ? "Sending..." : "Resend confirmation email"}
+                  </button>
+                </div>
                 <Button type="submit" className="w-full" disabled={loading}>
                   {loading ? "Signing in..." : "Sign In"}
                 </Button>

--- a/supabase/functions/reinvite-incomplete/index.ts
+++ b/supabase/functions/reinvite-incomplete/index.ts
@@ -1,0 +1,302 @@
+// Edge function: reinvite-incomplete
+// Re-invites users whose accounts are stuck unconfirmed (their original
+// signup confirmation email was never delivered). Generates a fresh
+// confirmation link per user and sends it via Brevo, recording each send
+// in public.signup_reminders.
+//
+// Caller must be an authenticated admin (user_roles.role = 'admin').
+//
+// Body (all optional):
+//   dryRun            boolean  default TRUE — no emails, no writes; reports what would happen
+//   limit             number   default 50   — max users processed this run
+//   excludeEmails     string[] default []   — emails to skip (e.g. internal test accounts)
+//   minAccountAgeHours number  default 24   — skip accounts younger than this
+//   maxReminders      number   default 3    — skip users already reminded this many times
+//   cooldownDays      number   default 7    — skip users reminded within this window
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.4";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const BREVO_API_KEY = Deno.env.get("BREVO_API_KEY");
+const BREVO_SENDER_EMAIL = Deno.env.get("BREVO_SENDER_EMAIL") || "no-reply@laceup.com";
+const BREVO_SENDER_NAME = Deno.env.get("BREVO_SENDER_NAME") || "LaceUp";
+// Optional: where the confirmation link should land after verification.
+// Must be on the auth redirect allow-list. When unset, GoTrue's configured
+// Site URL is used.
+const REINVITE_REDIRECT_URL = Deno.env.get("REINVITE_REDIRECT_URL");
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error("Missing Supabase service role configuration for reinvite-incomplete");
+}
+
+if (!BREVO_API_KEY) {
+  throw new Error("Missing BREVO_API_KEY for reinvite-incomplete function");
+}
+
+const badRequest = (message: string, status = 400) =>
+  new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+const ok = (data: Record<string, unknown> = {}) =>
+  new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+
+const reinviteHtml = (firstName: string, actionLink: string) => `<!doctype html>
+<html><body style="font-family: Arial, Helvetica, sans-serif; color: #0A2849; max-width: 560px; margin: 0 auto;">
+  <h2>Finish setting up your LaceUP account</h2>
+  <p>Hi${firstName ? ` ${escapeHtml(firstName)}` : ""},</p>
+  <p>You signed up for LaceUP, but our confirmation email never reached you &mdash; that was our fault, and it's fixed now.</p>
+  <p>Your account is still waiting for you. Click below to confirm your email and pick up where you left off:</p>
+  <p style="margin: 24px 0;">
+    <a href="${actionLink}"
+       style="background: #E8B555; color: #0A2849; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: bold;">
+      Confirm my account
+    </a>
+  </p>
+  <p style="font-size: 13px; color: #555;">This link expires after a short time. If it has expired, visit the sign-in page and choose &ldquo;Resend confirmation email.&rdquo;</p>
+  <p style="font-size: 13px; color: #555;">If you didn't sign up for LaceUP, you can safely ignore this email.</p>
+</body></html>`;
+
+interface ReinviteResult {
+  email: string;
+  status: "sent" | "would_send" | "skipped" | "error";
+  reason?: string;
+  linkType?: "signup" | "magiclink";
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  // Client bound to the caller's JWT — used only to identify the caller
+  const callerClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    global: {
+      headers: { Authorization: req.headers.get("Authorization") ?? "" },
+    },
+  });
+
+  // Pure service-role client for admin operations and reminder writes
+  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  try {
+    // Authorized callers: the service role key directly (ops/cron), or a
+    // signed-in user holding the admin role.
+    const bearer = (req.headers.get("Authorization") ?? "").replace(/^Bearer\s+/i, "");
+    const isServiceRoleCall = bearer.length > 0 && bearer === SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!isServiceRoleCall) {
+      const { data: authData, error: authError } = await callerClient.auth.getUser();
+      if (authError || !authData?.user) {
+        return badRequest("Unauthorized", 401);
+      }
+
+      const { data: adminRole } = await admin
+        .from("user_roles")
+        .select("user_id")
+        .eq("user_id", authData.user.id)
+        .eq("role", "admin")
+        .limit(1);
+
+      if (!adminRole || adminRole.length === 0) {
+        return badRequest("Admin access required", 403);
+      }
+    }
+
+    const body = (await req.json().catch(() => ({}))) ?? {};
+    const dryRun = body.dryRun !== false; // default true: must send dryRun:false to actually email
+    const limit = Math.min(Math.max(Number(body.limit) || 50, 1), 500);
+    const minAccountAgeHours = Number.isFinite(Number(body.minAccountAgeHours))
+      ? Number(body.minAccountAgeHours)
+      : 24;
+    const maxReminders = Number.isFinite(Number(body.maxReminders)) ? Number(body.maxReminders) : 3;
+    const cooldownDays = Number.isFinite(Number(body.cooldownDays)) ? Number(body.cooldownDays) : 7;
+    const excludeEmails = new Set(
+      (Array.isArray(body.excludeEmails) ? body.excludeEmails : [])
+        .filter((e: unknown): e is string => typeof e === "string")
+        .map((e: string) => e.trim().toLowerCase()),
+    );
+
+    // 1. Collect all unconfirmed users via the admin API
+    const unconfirmed: { id: string; email: string; created_at: string; first_name: string }[] = [];
+    let page = 1;
+    while (true) {
+      const { data: pageData, error: listError } = await admin.auth.admin.listUsers({
+        page,
+        perPage: 1000,
+      });
+      if (listError) {
+        console.error("reinvite-incomplete: listUsers error", listError);
+        return badRequest("Unable to list users.", 500);
+      }
+      for (const u of pageData.users) {
+        if (!u.email_confirmed_at && u.email) {
+          unconfirmed.push({
+            id: u.id,
+            email: u.email.toLowerCase(),
+            created_at: u.created_at,
+            first_name: (u.user_metadata?.first_name as string) ?? "",
+          });
+        }
+      }
+      if (pageData.users.length < 1000) break;
+      page += 1;
+    }
+
+    // 2. Load reminder history for skip rules
+    const { data: reminderRows } = await admin
+      .from("signup_reminders")
+      .select("user_id, reminder_count, last_reminded_at")
+      .in("user_id", unconfirmed.map((u) => u.id));
+    const reminders = new Map((reminderRows ?? []).map((r) => [r.user_id, r]));
+
+    const now = Date.now();
+    const minAgeCutoff = now - minAccountAgeHours * 60 * 60 * 1000;
+    const cooldownCutoff = now - cooldownDays * 24 * 60 * 60 * 1000;
+
+    const results: ReinviteResult[] = [];
+    const eligible: typeof unconfirmed = [];
+
+    for (const u of unconfirmed) {
+      const reminder = reminders.get(u.id);
+      if (excludeEmails.has(u.email)) {
+        results.push({ email: u.email, status: "skipped", reason: "excluded" });
+      } else if (new Date(u.created_at).getTime() > minAgeCutoff) {
+        results.push({ email: u.email, status: "skipped", reason: "account_too_new" });
+      } else if (reminder && reminder.reminder_count >= maxReminders) {
+        results.push({ email: u.email, status: "skipped", reason: "max_reminders_reached" });
+      } else if (
+        reminder?.last_reminded_at &&
+        new Date(reminder.last_reminded_at).getTime() > cooldownCutoff
+      ) {
+        results.push({ email: u.email, status: "skipped", reason: "cooldown" });
+      } else if (eligible.length >= limit) {
+        results.push({ email: u.email, status: "skipped", reason: "over_limit" });
+      } else {
+        eligible.push(u);
+      }
+    }
+
+    // 3. Generate a fresh confirmation link and (unless dry run) email it
+    for (const u of eligible) {
+      // "signup" regenerates the email-confirmation link for an unconfirmed
+      // user; fall back to a magic link (verifying it also proves email
+      // ownership, which confirms the account).
+      let actionLink: string | null = null;
+      let linkType: "signup" | "magiclink" = "signup";
+
+      const linkOptions = REINVITE_REDIRECT_URL ? { redirectTo: REINVITE_REDIRECT_URL } : undefined;
+
+      const signupLink = await admin.auth.admin.generateLink({
+        type: "signup",
+        email: u.email,
+        password: crypto.randomUUID(), // ignored for existing users; required by the API shape
+        options: linkOptions,
+      });
+
+      if (!signupLink.error && signupLink.data?.properties?.action_link) {
+        actionLink = signupLink.data.properties.action_link;
+      } else {
+        const magicLink = await admin.auth.admin.generateLink({
+          type: "magiclink",
+          email: u.email,
+          options: linkOptions,
+        });
+        if (!magicLink.error && magicLink.data?.properties?.action_link) {
+          actionLink = magicLink.data.properties.action_link;
+          linkType = "magiclink";
+        } else {
+          console.error("reinvite-incomplete: generateLink failed", u.id, signupLink.error, magicLink.error);
+          results.push({ email: u.email, status: "error", reason: "link_generation_failed" });
+          continue;
+        }
+      }
+
+      if (dryRun) {
+        results.push({ email: u.email, status: "would_send", linkType });
+        continue;
+      }
+
+      const brevoResponse = await fetch("https://api.brevo.com/v3/smtp/email", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "api-key": BREVO_API_KEY,
+        },
+        body: JSON.stringify({
+          to: [{ email: u.email, name: u.first_name || u.email }],
+          sender: { email: BREVO_SENDER_EMAIL, name: BREVO_SENDER_NAME },
+          subject: "Finish setting up your LaceUP account",
+          htmlContent: reinviteHtml(u.first_name, actionLink),
+        }),
+      });
+
+      if (!brevoResponse.ok) {
+        const brevoError = await brevoResponse.json().catch(() => ({}));
+        console.error("reinvite-incomplete: brevo error", u.id, brevoError);
+        results.push({ email: u.email, status: "error", reason: "brevo_send_failed" });
+        continue;
+      }
+
+      const brevoJson = await brevoResponse.json().catch(() => ({ messageId: null }));
+      const providerMessageId = typeof brevoJson?.messageId === "string" ? brevoJson.messageId : null;
+
+      const existing = reminders.get(u.id);
+      const stamp = existing
+        ? admin
+            .from("signup_reminders")
+            .update({
+              reminder_count: existing.reminder_count + 1,
+              last_reminded_at: new Date().toISOString(),
+              last_provider_message_id: providerMessageId,
+            })
+            .eq("user_id", u.id)
+        : admin.from("signup_reminders").insert({
+            user_id: u.id,
+            email: u.email,
+            reminder_count: 1,
+            last_reminded_at: new Date().toISOString(),
+            last_provider_message_id: providerMessageId,
+          });
+      const { error: stampError } = await stamp;
+      if (stampError) {
+        console.error("reinvite-incomplete: reminder stamp error", u.id, stampError);
+      }
+
+      results.push({ email: u.email, status: "sent", linkType });
+    }
+
+    const summary = {
+      dryRun,
+      totalUnconfirmed: unconfirmed.length,
+      sent: results.filter((r) => r.status === "sent").length,
+      wouldSend: results.filter((r) => r.status === "would_send").length,
+      skipped: results.filter((r) => r.status === "skipped").length,
+      errors: results.filter((r) => r.status === "error").length,
+      results,
+    };
+
+    return ok(summary);
+  } catch (error) {
+    console.error("reinvite-incomplete: unexpected error", error);
+    return badRequest("Unexpected error processing re-invites.", 500);
+  }
+});

--- a/supabase/migrations/20260731_add_signup_reminders.sql
+++ b/supabase/migrations/20260731_add_signup_reminders.sql
@@ -1,0 +1,40 @@
+-- Migration: Add signup_reminders tracking table
+-- Created: 2026-07-31
+-- Ticket: Investigate Incomplete Accounts
+--
+-- Tracks re-invite emails sent to users whose accounts are stuck unconfirmed
+-- (signup confirmation emails failed while Brevo was out of credits).
+-- Written to exclusively by the reinvite-incomplete edge function (service
+-- role); readable by admins for support/auditing.
+
+CREATE TABLE IF NOT EXISTS public.signup_reminders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+  email text NOT NULL,
+  reminder_count integer NOT NULL DEFAULT 0,
+  last_reminded_at timestamptz,
+  last_provider_message_id text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_signup_reminders_last_reminded_at
+  ON public.signup_reminders (last_reminded_at);
+
+ALTER TABLE public.signup_reminders ENABLE ROW LEVEL SECURITY;
+
+-- Admins can read reminder history; nobody else needs access.
+-- The edge function writes with the service role, which bypasses RLS.
+DROP POLICY IF EXISTS signup_reminders_admin_select ON public.signup_reminders;
+CREATE POLICY signup_reminders_admin_select
+  ON public.signup_reminders
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_roles
+      WHERE user_roles.user_id = auth.uid()
+      AND user_roles.role = 'admin'
+    )
+  );
+
+GRANT SELECT ON public.signup_reminders TO authenticated;
+GRANT ALL ON public.signup_reminders TO service_role;


### PR DESCRIPTION
42 of 185 signups (Jan-Jul 2026) never received their confirmation email while Brevo was out of credits, leaving accounts unconfirmed and those emails locked out. Per ticket: keep the accounts, re-invite them.

- signup_reminders table (migration applied to live): tracks re-invite count, last send, and Brevo message id per user; admin-readable.
- reinvite-incomplete edge function (deployed): lists unconfirmed auth users, generates a fresh signup confirmation link per user, sends via Brevo inline HTML, stamps signup_reminders. Guards: dryRun defaults TRUE, min account age 24h, 7-day cooldown, max 3 reminders, limit, excludeEmails. Callable by service key or signed-in admin. Dry-run verified against live: 41 would_send, 0 errors.
- /auth sign-in tab: self-service "Resend confirmation email" button (supabase.auth.resend) with anti-enumeration messaging.
- docs/INCOMPLETE_ACCOUNTS.md: runbook + future cron automation notes.